### PR TITLE
Support load firmware from XPI into ILM

### DIFF
--- a/src/host/linker/boot_header.x
+++ b/src/host/linker/boot_header.x
@@ -8,7 +8,7 @@ SECTIONS
     KEEP(*(.boot_header));
 
     . = ORIGIN(REGION_BOOT_FLASH) + 0x3000;
-    __app_load_addr__ = .;
-    __app_offset__ = __app_load_addr__ - __boot_header;
+    __app_load_addr__ = _stext;
+    __app_offset__ = . - __boot_header;
   } > REGION_BOOT_FLASH
 }

--- a/src/host/linker/hpmrt-link.x
+++ b/src/host/linker/hpmrt-link.x
@@ -41,10 +41,12 @@ PROVIDE(_start_trap = default_start_trap);
 
 SECTIONS
 {
-  .text _stext :
+  .text : ALIGN(4)
   {
     /* Put reset handler first in .text section so it ends up as the entry */
     /* point of the program. */
+    _sitext = LOADADDR(.text);
+    _stext = .;
     KEEP(*(.init));
     KEEP(*(.init.rust));
     . = ALIGN(4);
@@ -84,7 +86,7 @@ SECTIONS
     _edata = .;
   } > REGION_DATA AT> REGION_LOAD_DATA
 
-  __fw_size__ = _sidata - _stext + SIZEOF(.data);
+  __fw_size__ = _sidata - _sitext + SIZEOF(.data);
 
   .bss (NOLOAD) :
   {


### PR DESCRIPTION
## 说明

添加构建选项 `load_from_flash()`，支持利用 BootROM 的固件搬运功能，将固件从 XPI 搬运到 ILM 中并跳转到 `entry_point` 执行，加快 firmware 的执行速度。

## 限制

`.data` 和 `.trap` 的 LMA 同样需要设置为 XPI，在执行 `init_data` 时仍会从 XPI 进行搬运。